### PR TITLE
Fix missing unmount sdcard option

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -221,7 +221,7 @@
     <bool name="config_enableLockScreenRotation">false</bool>
 
     <!-- Indicate whether the SD card is accessible without removing the battery. -->
-    <bool name="config_batterySdCardAccessibility">false</bool>
+    <bool name="config_batterySdCardAccessibility">true</bool>
 
     <!-- Disable the home key unlock setting -->
     <!-- <bool name="config_disableHomeUnlockSetting">false</bool> -->


### PR DESCRIPTION
Set config_batterySdCardAccessibility option to true to enable eject sdcard option in settings->storage
